### PR TITLE
New setting in definitions.h GO_BACKWARD_UNTIL_INSIDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ boundary wire reciever coils in the following configuration
    |&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; (0)|<br/>
    |(2)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|  ----> Mowing direction<br/>
    |&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(1)|</br>
-    -----------------</br>
+    ----------------</br>
      wheel</br>
+<br/>
 </div>
 
+Licensed under GNU GPL 3.0 
 
-(c) Jonas Forssell & team
-Free to use for all.
+(c) 2017 Jonas Forssell & team
 
 Configuration
 ------

--- a/liam/Controller.cpp
+++ b/liam/Controller.cpp
@@ -137,7 +137,22 @@ int CONTROLLER::waitWhileInside(int duration) {
   return 0;      
   }
 
-
+#ifdef GO_BACKWARD_UNTIL_INSIDE
+int CONTROLLER::GoBackwardUntilInside (BWFSENSOR *Sensor) {
+	int counter=MAX_GO_BACKWARD_TIME;
+	//Mover has just stoped. Let it pause for a second.
+	delay(1000);
+	while(Sensor->isInside()==false)
+	{
+		runBackward(FULLSPEED);
+		delay(1000);
+		counter--;
+		if(counter<=0)
+			return 1;
+	}
+	return 0;
+}
+#endif
 void CONTROLLER::startCutter() {
 	for (int i=0; i<CUTTERSPEED; i++) 
 		cutter->setSpeed(i);

--- a/liam/Controller.h
+++ b/liam/Controller.h
@@ -28,7 +28,7 @@ class CONTROLLER {
         int turnToReleaseRight(int degrees);
         int waitWhileChecking(int duration);
         int waitWhileInside(int duration);
-        
+	int GoBackwardUntilInside(BWFSENSOR *Sensor);
         void runForward(int speed);
         void runBackward(int speed);
         void stop();

--- a/liam/Definition.h
+++ b/liam/Definition.h
@@ -117,6 +117,12 @@ const int CHARGING = 3;
 #define SLOWSPEED						30
 #define CUTTERSPEED						100
 
+// Enable this if you need the mower to go backward until it's inside and then turn.
+// Default behavior is to turn directly when mower is outside BWF, if definition below is enabled this might help mower not to get stuck in slopes.
+// If mower is not inside within x seconds mower will stop.
+//#define GO_BACKWARD_UNTIL_INSIDE
+//#define MAX_GO_BACKWARD_TIME  5 // try to get inside for max x seconds, then stop and error.
+
 class DEFINITION {
     public:
         void definePinsInputOutput();

--- a/liam/Error.cpp
+++ b/liam/Error.cpp
@@ -90,8 +90,8 @@ void ERROR::flag(int error_number_) {
   case 9:
     mylcd->setCursor(0,2);
     mylcd->print("Mower tilted");
-    break;  
-  } 
+    break;
+  }
 
   // blink LED forever
   while (true) 


### PR DESCRIPTION
New setting in definition.h that makes the mower reverse before changing direction when it has reached BWF. Also a setting for the maximum amount of time to run backward when this function is active.
I also changed from several "int err" in Liam.ino to one that's reachable within this scope. 

Errorcode if mower has run backward longer or equal to maximum amount of time is same as when mower is outside it's boundaries == errorcode 2.