### PR TITLE
Create myLcd.cpp

### DIFF
--- a/liam/myLcd.cpp
+++ b/liam/myLcd.cpp
@@ -59,7 +59,7 @@ void myLCD::setCursor(int col, int row) {
     }
     
 size_t myLCD::write(uint8_t s) {
-    	lcd.print(s);
+    	lcd.write(s);
     }
 
 void myLCD::clear() {


### PR DESCRIPTION
Use of write instead of print in function "write" in myLCD to avoid argument to be printed as ascii
numbers on LCD instead of ascii character.