### PR TITLE
Set c++-mode in Emacs

### DIFF
--- a/Liam/Liam.ino
+++ b/Liam/Liam.ino
@@ -520,3 +520,9 @@ void loop() {
   }
 #endif
 }
+
+// The following sets C++ mode in Emacs
+//
+// Local Variables:
+// mode:c++
+// End:


### PR DESCRIPTION
The commonly used editor Emacs has editing modes for different programming languages. It usually determines the programming mode based on file extension, but .ino is not recognized by default. By adding the following comment at the end of the file (where it doesn't disturb anyone), C++ mode will be automatically set.